### PR TITLE
docs: open a project in a new window of vs code

### DIFF
--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -25,7 +25,7 @@ npx nuxi init nuxt3-app
 Open `nuxt3-app` folder in visual studio code:
 
 ```bash
-code -r nuxt3-app
+code -n nuxt3-app
 ```
 
 Install the dependencies:


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

<!--
### 🔗 Linked issue
-->
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

I was getting started to NuxtJS but already opened another project in a text editor like VScode. Following along the installation guide, I lost the VScode window in which I was working on another project.

Therefore, I would like to open a new window of vs code instead of forcing to open a project in an already opened window.

`code --help` says : 

```bash
Visual Studio Code 1.63.2

Usage: code [options][paths...]

To read from stdin, append '-' (e.g. 'ps aux | grep code | code -')

Options
  ...
  -n --new-window                   Force to open a new window.
  -r --reuse-window                 Force to open a file or folder in an already opened window.
  ...
```

<br />

Hence, I changed the `Open nuxt3-app folder in visual studio code` part : 

```diff
- code -r nuxt3-app
+ code -n nuxt3-app
```

<br />

Any suggestion and feedback are appreciated !

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

